### PR TITLE
Add access to pdf components and add Mix3/MixN combinators

### DIFF
--- a/tensorprob/__init__.py
+++ b/tensorprob/__init__.py
@@ -29,9 +29,10 @@ logger.addHandler(handler)
 from . import config
 from . import utilities
 from . import distributions
-from .distribution import Distribution, DistributionError, Region
+from .distribution import Distribution, DistributionError
 from .model import Model, ModelError
 from .parameter import Parameter
 from .distributions import *
 from .optimizers import *
 from .samplers import *
+from .utilities import Region

--- a/tensorprob/distribution.py
+++ b/tensorprob/distribution.py
@@ -100,9 +100,15 @@ def Distribution(distribution_init):
 
         # Add the new variables to the model description
         for variable, bound in zip(variables, bounds):
-            Model.current_model._description[variable] = Description(
-                Distribution.logp, Distribution.integral, bound
+            description = Description(
+                Distribution.logp,
+                Distribution.integral,
+                bound,
+                tf.constant(1, config.dtype),
+                [X for X in Model.current_model._full_description if X in args]
             )
+            Model.current_model._description[variable] = description
+            Model.current_model._full_description[variable] = description
 
         return variable if len(variables) == 1 else variables
     return f

--- a/tensorprob/distribution.py
+++ b/tensorprob/distribution.py
@@ -51,8 +51,8 @@ def Distribution(distribution_init):
         Distribution.depends: (optional) list of tensorflow.Tensor
             The sub-distributions of this distribution
 
-    Most distributions are bounded automatically however some distributions,
-    such as combiantors, require access to the bounds of the distribution.
+    Most distributions are bounded automatically, however some distributions,
+    such as combinators, require access to the bounds of the distribution.
     These can be accessed using `Distribution.bounds(N)`.
 
     # Arguments:

--- a/tensorprob/distribution.py
+++ b/tensorprob/distribution.py
@@ -5,7 +5,8 @@ import tensorflow as tf
 
 from . import config
 from . import utilities
-from .model import Description, Model, ModelError, Region
+from .model import Model, ModelError
+from .utilities import Description, Region
 
 
 class DistributionError(Exception):
@@ -47,6 +48,8 @@ def Distribution(distribution_init):
         Distribution.integral: function
             A function with arguments (lower, upper) that returns the integral
             of the function between the specifed bounds.
+        Distribution.depends: (optional) list of tensorflow.Tensor
+            The sub-distributions of this distribution
 
     Most distributions are bounded automatically however some distributions,
     such as combiantors, require access to the bounds of the distribution.
@@ -78,6 +81,7 @@ def Distribution(distribution_init):
 
         Distribution.logp = None
         Distribution.integral = None
+        Distribution.depends = []
         Distribution.bounds = lambda ndim: _parse_bounds(ndim, lower, upper, bounds)
         variables = distribution_init(*args, name=name)
 
@@ -107,7 +111,7 @@ def Distribution(distribution_init):
                 Distribution.integral,
                 bound,
                 tf.constant(1, config.dtype),
-                [X for X in Model.current_model._full_description if X in args]
+                Distribution.depends
             )
             Model.current_model._description[variable] = description
             Model.current_model._full_description[variable] = description

--- a/tensorprob/distributions/__init__.py
+++ b/tensorprob/distributions/__init__.py
@@ -1,4 +1,4 @@
-from .combinators import Mix2
+from .combinators import Mix2, Mix3
 from .exponential import Exponential
 from .normal import Normal
 from .poisson import Poisson

--- a/tensorprob/distributions/__init__.py
+++ b/tensorprob/distributions/__init__.py
@@ -1,4 +1,4 @@
-from .combinators import Mix2, Mix3
+from .combinators import Mix2, Mix3, MixN
 from .exponential import Exponential
 from .normal import Normal
 from .poisson import Poisson

--- a/tensorprob/distributions/combinators.py
+++ b/tensorprob/distributions/combinators.py
@@ -40,12 +40,12 @@ def _recurse_deps(X, f_scale, bounds):
 
 @Distribution
 def Mix2(f, A, B, name=None):
-    return _MixN([A, B], [f, 1-f], name)
+    return _MixN([f, 1-f], [A, B], name)
 
 
 @Distribution
 def Mix3(f1, f2, A, B, C, name=None):
-    return _MixN([A, B, C], [f1*f2, (1-f1)*f2, (1-f2)], name)
+    return _MixN([f1*f2, (1-f1)*f2, (1-f2)], [A, B, C], name)
 
 
 @Distribution
@@ -56,10 +56,10 @@ def MixN(fs, Xs, name=None):
     for f in fs[1:]:
         fractions = [f*frac for frac in fractions]
         fractions.append(1-f)
-    return _MixN(Xs, fractions, name)
+    return _MixN(fractions, Xs, name)
 
 
-def _MixN(Xs, fractions, name=None):
+def _MixN(fractions, Xs, name=None):
     # TODO(chrisburr) Check if f is bounded between 0 and 1?
     X = tf.placeholder(config.dtype, name=name)
     mix_bounds = Distribution.bounds(1)[0]

--- a/tensorprob/distributions/combinators.py
+++ b/tensorprob/distributions/combinators.py
@@ -48,6 +48,17 @@ def Mix3(f1, f2, A, B, C, name=None):
     return _MixN([A, B, C], [f1*f2, (1-f1)*f2, (1-f2)], name)
 
 
+@Distribution
+def MixN(fs, Xs, name=None):
+    # Eqivilent to calling Mix2(Mix2(Mix2(Mix2(A, B), C), D), E)
+    assert len(fs)+1 == len(Xs)
+    fractions = [fs[0], 1-fs[0]]
+    for f in fs[1:]:
+        fractions = [f*frac for frac in fractions]
+        fractions.append(1-f)
+    return _MixN(Xs, fractions, name)
+
+
 def _MixN(Xs, fractions, name=None):
     # TODO(chrisburr) Check if f is bounded between 0 and 1?
     X = tf.placeholder(config.dtype, name=name)

--- a/tensorprob/distributions/combinators.py
+++ b/tensorprob/distributions/combinators.py
@@ -16,19 +16,39 @@ def Mix2(f, A, B, name=None):
     b_logp, b_integral, b_bounds, b_frac, _ = Model._current_model._description[B]
 
     def _integral(mix_bounds, sub_bounds, sub_integral):
+        """Calculate the normalistion and bounds for the sub-distributions.
+
+        # Arguments
+            mix_bounds: list of `Region` objects
+                The allowed regions for the combined distribution
+            sub_bounds: list of `Region` objects
+                The allowed regions for the sub-distribution
+            sub_integral: function
+                The integral function of the sub-distribution
+
+        # Returns
+            result: TensorFlow Variable
+                Result of calculating `sub_integral` with the provided bounds
+            new_bounds: list of `Region` objects
+                The reduced set of bounds that now apply to the distribution
+        """
         # Calculate the normalised logp
         integrals = []
+        new_bounds = []
         for (mix_lower, mix_upper), (sub_lower, sub_upper) in product(mix_bounds, sub_bounds):
             # Ignore this region if it's outside the current limits
             if sub_upper <= mix_lower or mix_upper <= sub_lower:
                 continue
+            new_bounds.append(Region(max(sub_lower, mix_lower), min(sub_upper, mix_upper)))
             # Else keep the region, tightening the edges as reqired
             integrals.append(sub_integral(max(sub_lower, mix_lower), min(sub_upper, mix_upper)))
-        return tf.add_n(integrals) if integrals else tf.constant(1, config.dtype)
+
+        result = tf.add_n(integrals) if integrals else tf.constant(1, config.dtype)
+        return result, new_bounds
 
     bounds = Distribution.bounds(1)[0]
-    a_normalisation_1 = _integral(bounds, a_bounds, a_integral)
-    b_normalisation_1 = _integral(bounds, b_bounds, b_integral)
+    a_normalisation_1, a_bounds = _integral(bounds, a_bounds, a_integral)
+    b_normalisation_1, b_bounds = _integral(bounds, b_bounds, b_integral)
 
     Distribution.logp = tf.log(
         f*tf.exp(a_logp)/a_normalisation_1 +
@@ -36,8 +56,8 @@ def Mix2(f, A, B, name=None):
     )
 
     def integral(lower, upper):
-        a_normalisation_2 = _integral([Region(lower, upper)], a_bounds, a_integral)
-        b_normalisation_2 = _integral([Region(lower, upper)], b_bounds, b_integral)
+        a_normalisation_2, _ = _integral([Region(lower, upper)], a_bounds, a_integral)
+        b_normalisation_2, _ = _integral([Region(lower, upper)], b_bounds, b_integral)
 
         return f/a_normalisation_1*a_normalisation_2 + (1-f)/b_normalisation_1*b_normalisation_2
 
@@ -63,14 +83,14 @@ def Mix2(f, A, B, name=None):
 
     # Add the fractions to Model._full_description
     logp, integral, bounds, frac, deps = Model._current_model._full_description[A]
-    Model._current_model._full_description[A] = Description(logp, integral, bounds, frac*f, deps)
+    Model._current_model._full_description[A] = Description(logp, integral, a_bounds, frac*f, deps)
 
     for dep in deps:
         logp, integral, bounds, frac, _ = Model._current_model._full_description[dep]
         Model._current_model._full_description[dep] = Description(logp, integral, bounds, frac*f, deps)
 
     logp, integral, bounds, frac, deps = Model._current_model._full_description[B]
-    Model._current_model._full_description[B] = Description(logp, integral, bounds, frac*(1-f), deps)
+    Model._current_model._full_description[B] = Description(logp, integral, b_bounds, frac*(1-f), deps)
 
     for dep in deps:
         logp, integral, bounds, frac, _ = Model._current_model._full_description[dep]

--- a/tensorprob/distributions/combinators.py
+++ b/tensorprob/distributions/combinators.py
@@ -43,6 +43,11 @@ def Mix2(f, A, B, name=None):
     return _MixN([A, B], [f, 1-f], name)
 
 
+@Distribution
+def Mix3(f1, f2, A, B, C, name=None):
+    return _MixN([A, B, C], [f1*f2, (1-f1)*f2, (1-f2)], name)
+
+
 def _MixN(Xs, fractions, name=None):
     # TODO(chrisburr) Check if f is bounded between 0 and 1?
     X = tf.placeholder(config.dtype, name=name)

--- a/tensorprob/distributions/combinators.py
+++ b/tensorprob/distributions/combinators.py
@@ -64,9 +64,7 @@ def Mix2(f, A, B, name=None):
     Distribution.integral = integral
 
     # Modify the current model to recognize that X and Y have been removed
-    for dist in A, B:
-        # TODO(chrisburr) Explain
-        # TODO(chrisburr) Add test for combinators of combinators
+    for dist, new_bounds, f_scale in zip((A, B), (a_bounds, b_bounds), (f, 1-f)):
         if dist in Model._current_model._silently_replace.values():
             # We need to copy the items to a list as we're deleting items from
             # the dictionary
@@ -81,19 +79,12 @@ def Mix2(f, A, B, name=None):
             Model._current_model._silently_replace[dist] = X
             del Model._current_model._description[dist]
 
-    # Add the fractions to Model._full_description
-    logp, integral, bounds, frac, deps = Model._current_model._full_description[A]
-    Model._current_model._full_description[A] = Description(logp, integral, a_bounds, frac*f, deps)
+        # Add the fractions and new bounds to Model._full_description
+        logp, integral, bounds, frac, deps = Model._current_model._full_description[dist]
+        Model._current_model._full_description[dist] = Description(logp, integral, new_bounds, frac*f_scale, deps)
 
-    for dep in deps:
-        logp, integral, bounds, frac, _ = Model._current_model._full_description[dep]
-        Model._current_model._full_description[dep] = Description(logp, integral, bounds, frac*f, deps)
-
-    logp, integral, bounds, frac, deps = Model._current_model._full_description[B]
-    Model._current_model._full_description[B] = Description(logp, integral, b_bounds, frac*(1-f), deps)
-
-    for dep in deps:
-        logp, integral, bounds, frac, _ = Model._current_model._full_description[dep]
-        Model._current_model._full_description[dep] = Description(logp, integral, bounds, frac*(1-f), deps)
+        for dep in deps:
+            logp, integral, bounds, frac, _ = Model._current_model._full_description[dep]
+            Model._current_model._full_description[dep] = Description(logp, integral, bounds, frac*f_scale, deps)
 
     return X

--- a/tensorprob/model.py
+++ b/tensorprob/model.py
@@ -1,20 +1,17 @@
-from collections import namedtuple
 import logging
 logger = logging.getLogger('tensorprob')
 
-import numpy as np
 import tensorflow as tf
 
 from . import config
-from .utilities import classproperty, generate_name, set_logp_to_neg_inf
-
-
-# Used to specify valid ranges for variables
-Region = namedtuple('Region', ['lower', 'upper'])
-# Used to describe a variable's role in the model
-Description = namedtuple('Description', ['logp', 'integral', 'bounds', 'fraction', 'deps'])
-# Used for returning components of a model
-ModelSubComponet = namedtuple('ModelSubComponet', ['pdf'])
+from .utilities import (
+    classproperty,
+    Description,
+    generate_name,
+    ModelSubComponet,
+    Region,
+    set_logp_to_neg_inf
+)
 
 
 class ModelError(RuntimeError):

--- a/tensorprob/model.py
+++ b/tensorprob/model.py
@@ -77,6 +77,32 @@ class Model(object):
         with self._model_graph.as_default():
             for var, (logp, integral, bounds, frac, _) in self._full_description.items():
                 logp -= tf.log(tf.add_n([integral(l, u) for l, u in bounds]))
+
+                # Force logp to negative infinity when outside the allowed bounds
+                conditions = []
+                for l, u in bounds:
+                    lower_is_neg_inf = not isinstance(l, tf.Tensor) and np.isneginf(l)
+                    upper_is_pos_inf = not isinstance(u, tf.Tensor) and np.isposinf(u)
+
+                    if not lower_is_neg_inf and upper_is_pos_inf:
+                        conditions.append(tf.greater(var, l))
+                    elif lower_is_neg_inf and not upper_is_pos_inf:
+                        conditions.append(tf.less(var, u))
+                    elif not (lower_is_neg_inf or upper_is_pos_inf):
+                        conditions.append(tf.logical_and(tf.greater(var, l), tf.less(var, u)))
+
+                if len(conditions) > 0:
+                    is_inside_bounds = conditions[0]
+                    for condition in conditions[1:]:
+                        is_inside_bounds = tf.logical_or(is_inside_bounds, condition)
+
+                    logp = tf.select(
+                        is_inside_bounds,
+                        logp,
+                        tf.fill(tf.shape(var), config.dtype(-np.inf))
+                    )
+
+                # Add the changed logp to the model description
                 self._full_description[var] = Description(logp, integral, bounds, frac, _)
                 if var in self._description:
                     self._description[var] = Description(logp, integral, bounds, frac, _)

--- a/tensorprob/utilities.py
+++ b/tensorprob/utilities.py
@@ -1,4 +1,4 @@
-from collections import defaultdict,  Iterable, namedtuple
+from collections import defaultdict, Iterable, namedtuple
 import itertools
 
 import numpy as np
@@ -113,7 +113,7 @@ def set_logp_to_neg_inf(X, logp, bounds):
 
 
 def find_common_bounds(bounds_1, bounds_2):
-    """Find a new set of boundries combining `bounds_1` and `bounds_2`
+    """Find a new set of boundaries combining `bounds_1` and `bounds_2`
 
     # Arguments
         bounds_1: list of `Region` objects

--- a/tensorprob/utilities.py
+++ b/tensorprob/utilities.py
@@ -1,4 +1,4 @@
-from collections import defaultdict, Iterable
+from collections import defaultdict,  Iterable, namedtuple
 import itertools
 
 import numpy as np
@@ -9,6 +9,14 @@ from . import config
 
 
 NAME_COUNTERS = defaultdict(lambda: 0)
+
+# CONTAINERS
+# Used to specify valid ranges for variables
+Region = namedtuple('Region', ['lower', 'upper'])
+# Used to describe a variable's role in the model
+Description = namedtuple('Description', ['logp', 'integral', 'bounds', 'fraction', 'deps'])
+# Used for returning components of a model
+ModelSubComponet = namedtuple('ModelSubComponet', ['pdf'])
 
 
 def generate_name(obj):
@@ -102,3 +110,22 @@ def set_logp_to_neg_inf(X, logp, bounds):
         )
 
     return logp
+
+
+def find_common_bounds(bounds_1, bounds_2):
+    """Find a new set of boundries combining `bounds_1` and `bounds_2`
+
+    # Arguments
+        bounds_1: list of `Region` objects
+        bounds_2: list of `Region` objects
+
+    # Returns
+        new_bounds: list of `Region` objects
+    """
+    new_bounds = []
+    for (lower_1, upper_1), (lower_2, upper_2) in itertools.product(bounds_1, bounds_2):
+        # Ignore this region if it's outside the current limits
+        if upper_1 <= lower_2 or upper_2 <= lower_1:
+            continue
+        new_bounds.append(Region(max(lower_1, lower_2), min(upper_1, upper_2)))
+    return new_bounds

--- a/tests/distributions/test_combinators.py
+++ b/tests/distributions/test_combinators.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipy.stats as st
 from numpy.testing import assert_array_almost_equal
 
-from tensorprob import Model, Parameter, Normal, Exponential, Mix2, Mix3
+from tensorprob import Model, Parameter, Normal, Exponential, Mix2, Mix3, MixN
 
 
 def test_mix2_fit():
@@ -189,6 +189,127 @@ def test_mix3_fit():
         X3 = Exponential(b)
 
         X123 = Mix3(f_1, f_2, X1, X2, X3, bounds=[(6, 17), (18, 36)])
+
+    model.observed(X123)
+    model.initialize({
+        mu: 23,
+        sigma: 1.2,
+        a: 0.2,
+        b: 0.04,
+        f_1: 0.3,
+        f_2: 0.4
+    })
+
+    # Generate some data to fit
+    np.random.seed(42)
+
+    exp_1_data = np.random.exponential(10, 200000)
+    exp_1_data = exp_1_data[
+        (6 < exp_1_data) &
+        ((exp_1_data < 8) | (10 < exp_1_data)) &
+        ((exp_1_data < 17) | (18 < exp_1_data)) &
+        ((exp_1_data < 27) | (31 < exp_1_data)) &
+        (exp_1_data < 36)
+    ]
+
+    exp_2_data = np.random.exponential(20, 200000)
+    exp_2_data = exp_2_data[
+        (6 < exp_2_data) &
+        ((exp_2_data < 17) | (18 < exp_2_data)) &
+        (exp_2_data < 36)
+    ]
+
+    # Include the data blinded by the Mix2 bounds as we use the len(norm_data)
+    norm_data = np.random.normal(19, 2, 100000)
+    norm_data = norm_data[
+        ((6 < norm_data) & (norm_data < 17)) |
+        ((18 < norm_data) & (norm_data < 21)) |
+        ((22 < norm_data) & (norm_data < 36))
+    ]
+
+    data = np.concatenate([exp_1_data, exp_2_data, norm_data])
+    data = data[((6 < data) & (data < 17)) | ((18 < data) & (data < 36))]
+
+    result = model.fit(data)
+
+    # Check the fit was successful
+    assert result.success
+    assert abs(model.state[mu] - 19) < 3e-2
+    assert abs(model.state[sigma] - 2) < 1e-3
+    assert abs(model.state[a] - 0.1) < 1e-3
+    assert abs(model.state[b] - 0.05) < 3e-4
+    assert abs(model.state[f_1] - (len(norm_data)/(len(exp_1_data)+len(norm_data)))) < 5e-3
+    assert abs(model.state[f_2] - ((len(exp_1_data)+len(norm_data))/len(data))) < 5e-4
+
+    # Check if we can access the individual components
+    xs = np.linspace(0, 41, 1001)
+
+    def allowed_point(x, bounds):
+        @np.vectorize
+        def allowed_point(x):
+            for l, u in bounds:
+                if l < x and x < u:
+                    return 1
+            return 0
+        return allowed_point(x)
+
+    # Normal
+    bounds = [(6, 17), (18, 21), (22, 36)]
+    out1 = st.norm.pdf(xs, model.state[mu], model.state[sigma]) * allowed_point(xs, bounds)
+    integral = sum(
+        st.norm.cdf(u, model.state[mu], model.state[sigma]) -
+        st.norm.cdf(l, model.state[mu], model.state[sigma])
+        for l, u in bounds
+    )
+    out1 *= model.state[f_1] * model.state[f_2] / integral
+
+    out2 = model[X1].pdf(xs)
+
+    assert_array_almost_equal(out1, out2, 11)
+
+    # Exponential 1
+    bounds = [(6, 8), (10, 17), (18, 27), (31, 36)]
+    out1 = st.expon.pdf(xs, 0, 1/model.state[a]) * allowed_point(xs, bounds)
+    integral = sum(
+        st.expon.cdf(u, 0, 1/model.state[a]) -
+        st.expon.cdf(l, 0, 1/model.state[a])
+        for l, u in bounds
+    )
+    out1 *= (1-model.state[f_1]) * model.state[f_2] / integral
+
+    out2 = model[X2].pdf(xs)
+
+    assert_array_almost_equal(out1, out2, 11)
+
+    # Exponential 2
+    bounds = [(6, 17), (18, 36)]
+    out1 = st.expon.pdf(xs, 0, 1/model.state[b]) * allowed_point(xs, bounds)
+    integral = sum(
+        st.expon.cdf(u, 0, 1/model.state[b]) -
+        st.expon.cdf(l, 0, 1/model.state[b])
+        for l, u in bounds
+    )
+    out1 *= (1-model.state[f_2]) / integral
+
+    out2 = model[X3].pdf(xs)
+
+    assert_array_almost_equal(out1, out2, 11)
+
+
+def test_mixn_fit():
+    with Model() as model:
+        mu = Parameter()
+        sigma = Parameter(lower=1, upper=4)
+        a = Parameter(lower=0.06)
+        b = Parameter(lower=0)
+        f_1 = Parameter(lower=0, upper=1)
+        f_2 = Parameter(lower=0, upper=1)
+
+        X1 = Normal(mu, sigma, bounds=[(-np.inf, 21), (22, np.inf)])
+        X2 = Exponential(a, bounds=[(-np.inf, 8), (10, 27), (31, np.inf)])
+        X3 = Exponential(b)
+
+        X123 = MixN([f_1, f_2], [X1, X2, X3], bounds=[(6, 17), (18, 36)])
 
     model.observed(X123)
     model.initialize({

--- a/tests/distributions/test_combinators.py
+++ b/tests/distributions/test_combinators.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipy.stats as st
 from numpy.testing import assert_array_almost_equal
 
-from tensorprob import Model, Parameter, Normal, Exponential, Mix2
+from tensorprob import Model, Parameter, Normal, Exponential, Mix2, Mix3
 
 
 def test_mix2_fit():
@@ -68,6 +68,127 @@ def test_mix2_fit_with_mix2_input():
 
         X3 = Exponential(b)
         X123 = Mix2(f_2, X12, X3, bounds=[(6, 17), (18, 36)])
+
+    model.observed(X123)
+    model.initialize({
+        mu: 23,
+        sigma: 1.2,
+        a: 0.2,
+        b: 0.04,
+        f_1: 0.3,
+        f_2: 0.4
+    })
+
+    # Generate some data to fit
+    np.random.seed(42)
+
+    exp_1_data = np.random.exponential(10, 200000)
+    exp_1_data = exp_1_data[
+        (6 < exp_1_data) &
+        ((exp_1_data < 8) | (10 < exp_1_data)) &
+        ((exp_1_data < 17) | (18 < exp_1_data)) &
+        ((exp_1_data < 27) | (31 < exp_1_data)) &
+        (exp_1_data < 36)
+    ]
+
+    exp_2_data = np.random.exponential(20, 200000)
+    exp_2_data = exp_2_data[
+        (6 < exp_2_data) &
+        ((exp_2_data < 17) | (18 < exp_2_data)) &
+        (exp_2_data < 36)
+    ]
+
+    # Include the data blinded by the Mix2 bounds as we use the len(norm_data)
+    norm_data = np.random.normal(19, 2, 100000)
+    norm_data = norm_data[
+        ((6 < norm_data) & (norm_data < 17)) |
+        ((18 < norm_data) & (norm_data < 21)) |
+        ((22 < norm_data) & (norm_data < 36))
+    ]
+
+    data = np.concatenate([exp_1_data, exp_2_data, norm_data])
+    data = data[((6 < data) & (data < 17)) | ((18 < data) & (data < 36))]
+
+    result = model.fit(data)
+
+    # Check the fit was successful
+    assert result.success
+    assert abs(model.state[mu] - 19) < 3e-2
+    assert abs(model.state[sigma] - 2) < 1e-3
+    assert abs(model.state[a] - 0.1) < 1e-3
+    assert abs(model.state[b] - 0.05) < 3e-4
+    assert abs(model.state[f_1] - (len(norm_data)/(len(exp_1_data)+len(norm_data)))) < 5e-3
+    assert abs(model.state[f_2] - ((len(exp_1_data)+len(norm_data))/len(data))) < 5e-4
+
+    # Check if we can access the individual components
+    xs = np.linspace(0, 41, 1001)
+
+    def allowed_point(x, bounds):
+        @np.vectorize
+        def allowed_point(x):
+            for l, u in bounds:
+                if l < x and x < u:
+                    return 1
+            return 0
+        return allowed_point(x)
+
+    # Normal
+    bounds = [(6, 17), (18, 21), (22, 36)]
+    out1 = st.norm.pdf(xs, model.state[mu], model.state[sigma]) * allowed_point(xs, bounds)
+    integral = sum(
+        st.norm.cdf(u, model.state[mu], model.state[sigma]) -
+        st.norm.cdf(l, model.state[mu], model.state[sigma])
+        for l, u in bounds
+    )
+    out1 *= model.state[f_1] * model.state[f_2] / integral
+
+    out2 = model[X1].pdf(xs)
+
+    assert_array_almost_equal(out1, out2, 11)
+
+    # Exponential 1
+    bounds = [(6, 8), (10, 17), (18, 27), (31, 36)]
+    out1 = st.expon.pdf(xs, 0, 1/model.state[a]) * allowed_point(xs, bounds)
+    integral = sum(
+        st.expon.cdf(u, 0, 1/model.state[a]) -
+        st.expon.cdf(l, 0, 1/model.state[a])
+        for l, u in bounds
+    )
+    out1 *= (1-model.state[f_1]) * model.state[f_2] / integral
+
+    out2 = model[X2].pdf(xs)
+
+    assert_array_almost_equal(out1, out2, 11)
+
+    # Exponential 2
+    bounds = [(6, 17), (18, 36)]
+    out1 = st.expon.pdf(xs, 0, 1/model.state[b]) * allowed_point(xs, bounds)
+    integral = sum(
+        st.expon.cdf(u, 0, 1/model.state[b]) -
+        st.expon.cdf(l, 0, 1/model.state[b])
+        for l, u in bounds
+    )
+    out1 *= (1-model.state[f_2]) / integral
+
+    out2 = model[X3].pdf(xs)
+
+    assert_array_almost_equal(out1, out2, 11)
+
+
+def test_mix3_fit():
+    with Model() as model:
+        mu = Parameter()
+        sigma = Parameter(lower=1, upper=4)
+        a = Parameter(lower=0.06)
+        b = Parameter(lower=0)
+        f_1 = Parameter(lower=0, upper=1)
+        f_2 = Parameter(lower=0, upper=1)
+
+        X1 = Normal(mu, sigma, bounds=[(-np.inf, 21), (22, np.inf)])
+        X2 = Exponential(a, bounds=[(-np.inf, 8), (10, 27), (31, np.inf)])
+        X3 = Exponential(b)
+
+        X123 = Mix3(f_1, f_2, X1, X2, X3, bounds=[(6, 17), (18, 36)])
 
     model.observed(X123)
     model.initialize({

--- a/tests/distributions/test_combinators.py
+++ b/tests/distributions/test_combinators.py
@@ -111,14 +111,6 @@ def test_mix2_fit_with_mix2_input():
 
     result = model.fit(data)
 
-    from matplotlib import pyplot as plt
-    from matplotlib_hep import histpoints
-    xs = np.linspace(-5, 41, 1000)
-    histpoints(data, bins=np.linspace(-5, 41, (41+5)*3+1), normed=True, ms=1)
-    plt.plot(xs, model.pdf(xs), 'b-')
-    plt.xlim(-5, 41)
-    plt.show()
-
     # Check the fit was successful
     assert result.success
     assert abs(model.state[mu] - 19) < 3e-2


### PR DESCRIPTION
- Adds a `Mix3(f1, f2, A, B, C)` combinator -> equivalent to `Mix2(f2, Mix2(f1, A, B), C)`
- Adds a `MixN(fractions, Xs)` combinator -> equivalent to chaining `Mix2` as is done in `Mix3`.
- Adds access to the pdf components (#40) like follows:

```python
with Model() as model:
    X1 = Normal(mu, sigma)
    X2 = Normal(mu, sigma)
    X = Mix2(f, X1, X2)

plt.plot(xs, model[X1].pdf(xs))
plt.plot(xs, model[X3].pdf(xs))
plt.plot(xs, model[X].pdf(xs))
```