### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(name='tensorprob',
           'tensorprob',
           'tensorprob.distributions',
           'tensorprob.optimizers',
+          'tensorprob.samplers'
       ],
       zip_safe=False)


### PR DESCRIPTION
I noticed the documentation webpage didn't update after merging #60. This appears to be because `tensorprob.samplers` was missing from `setup.py`, however, I'm not sure if moving to the `tensorprob` organsiation has caused additional issues as both changes were made at the same time.