### PR TITLE
Add partial support for extended likelihood fits

### DIFF
--- a/tensorprob/distributions/poisson.py
+++ b/tensorprob/distributions/poisson.py
@@ -8,8 +8,16 @@ from ..distribution import Distribution
 def Poisson(lambda_, name=None):
     k = tf.placeholder(config.int_dtype, name=name)
 
-    Distribution.logp = k*lambda_ - lambda_ + tf.lgamma(k+1)
+    # FIXME tf.lgamma only supports floats so cast before
+    Distribution.logp = (
+        tf.cast(k, config.dtype)*tf.log(lambda_) -
+        lambda_ -
+        tf.lgamma(tf.cast(k+1, config.dtype))
+    )
 
     # TODO Distribution.integral = ...
+    def integral(l, u):
+        return tf.constant(1, dtype=config.dtype)
+    Distribution.integral = integral
 
     return k

--- a/tensorprob/distributions/uniform.py
+++ b/tensorprob/distributions/uniform.py
@@ -1,4 +1,3 @@
-import numpy as np
 import tensorflow as tf
 
 from .. import config
@@ -33,14 +32,15 @@ def UniformInt(name=None):
     Distribution.logp = tf.fill(tf.shape(X), config.dtype(0))
 
     def integral(lower, upper):
-        return tf.cond(
+        val = tf.cond(
             tf.logical_or(
-                tf.is_inf(tf.cast(tf.ceil(lower), config.dtype)),
-                tf.is_inf(tf.cast(tf.floor(upper), config.dtype))
+                tf.is_inf(tf.ceil(tf.cast(lower, config.dtype))),
+                tf.is_inf(tf.floor(tf.cast(upper, config.dtype)))
             ),
             lambda: tf.constant(1, dtype=config.dtype),
             lambda: tf.cast(upper, config.dtype) - tf.cast(lower, config.dtype),
         )
+        return val
 
     Distribution.integral = integral
 

--- a/tensorprob/model.py
+++ b/tensorprob/model.py
@@ -356,8 +356,7 @@ class Model(object):
         # Assign values without adding to the graph
         setters = [self._setters[self._hidden[k]][0] for k, v in assign_dict.items()]
         feed_dict = {self._setters[self._hidden[k]][1]: v for k, v in assign_dict.items()}
-        for s in setters:
-            self.session.run(setters, feed_dict=feed_dict)
+        self.session.run(setters, feed_dict=feed_dict)
 
     @property
     def state(self):


### PR DESCRIPTION
This PR adds the partial support for extended likelihood fits by adding:
- Marginalisation of dimensions where it is possible to do so by ignoring a component of the logp
- Fixes with the Poisson/UniformInt distribution